### PR TITLE
Last seen block: as in-mem atomic instead of db field

### DIFF
--- a/remote/ethbackend.proto
+++ b/remote/ethbackend.proto
@@ -18,8 +18,8 @@ service ETHBACKEND {
   // Version returns the service version number
   rpc Version(google.protobuf.Empty) returns (types.VersionReply);
 
-  // LastNewBlockSeen
-  rpc LastNewBlockSeen(google.protobuf.Empty) returns (LastNewBlockSeenReply);
+  // Status
+  rpc Status(google.protobuf.Empty) returns (StatusReply);
 
   // ProtocolVersion returns the Ethereum protocol version number (e.g. 66 for ETH66).
   rpc ProtocolVersion(ProtocolVersionRequest) returns (ProtocolVersionReply);
@@ -85,7 +85,10 @@ message NetVersionRequest {}
 
 message NetVersionReply {uint64 id = 1;}
 
-message LastNewBlockSeenReply {uint64 block_number = 1;}
+message StatusReply {
+  uint64 last_new_block_seen = 1;
+  uint64 frozen_blocks = 2;
+}
 
 message NetPeerCountRequest {}
 

--- a/remote/ethbackend.proto
+++ b/remote/ethbackend.proto
@@ -90,6 +90,13 @@ message SyncingReply {
   uint64 frozen_blocks = 2;
   uint64 current_block = 3;
   bool syncing = 4;
+
+  message StageProgress {
+    string stage_name = 1;
+    uint64 block_number = 2;
+  }
+  repeated StageProgress stages = 5;
+  
 }
 
 message NetPeerCountRequest {}

--- a/remote/ethbackend.proto
+++ b/remote/ethbackend.proto
@@ -18,6 +18,9 @@ service ETHBACKEND {
   // Version returns the service version number
   rpc Version(google.protobuf.Empty) returns (types.VersionReply);
 
+  // LastNewBlockSeen
+  rpc LastNewBlockSeen(google.protobuf.Empty) returns (LastNewBlockSeenReply);
+
   // ProtocolVersion returns the Ethereum protocol version number (e.g. 66 for ETH66).
   rpc ProtocolVersion(ProtocolVersionRequest) returns (ProtocolVersionReply);
 
@@ -76,23 +79,25 @@ enum Event {
 
 message EtherbaseRequest {}
 
-message EtherbaseReply { types.H160 address = 1; }
+message EtherbaseReply {types.H160 address = 1;}
 
 message NetVersionRequest {}
 
-message NetVersionReply { uint64 id = 1; }
+message NetVersionReply {uint64 id = 1;}
+
+message LastNewBlockSeenReply {uint64 block_number = 1;}
 
 message NetPeerCountRequest {}
 
-message NetPeerCountReply { uint64 count = 1; }
+message NetPeerCountReply {uint64 count = 1;}
 
 message ProtocolVersionRequest {}
 
-message ProtocolVersionReply { uint64 id = 1; }
+message ProtocolVersionReply {uint64 id = 1;}
 
 message ClientVersionRequest {}
 
-message ClientVersionReply { string node_name = 1; }
+message ClientVersionReply {string node_name = 1;}
 
 message CanonicalHashRequest {
   uint64 block_number = 1;

--- a/remote/ethbackend.proto
+++ b/remote/ethbackend.proto
@@ -18,8 +18,8 @@ service ETHBACKEND {
   // Version returns the service version number
   rpc Version(google.protobuf.Empty) returns (types.VersionReply);
 
-  // Status
-  rpc Status(google.protobuf.Empty) returns (StatusReply);
+  // Syncing returns a data object detailing the status of the sync process
+  rpc Syncing(google.protobuf.Empty) returns (SyncingReply);
 
   // ProtocolVersion returns the Ethereum protocol version number (e.g. 66 for ETH66).
   rpc ProtocolVersion(ProtocolVersionRequest) returns (ProtocolVersionReply);
@@ -85,9 +85,11 @@ message NetVersionRequest {}
 
 message NetVersionReply {uint64 id = 1;}
 
-message StatusReply {
+message SyncingReply {
   uint64 last_new_block_seen = 1;
   uint64 frozen_blocks = 2;
+  uint64 current_block = 3;
+  bool syncing = 4;
 }
 
 message NetPeerCountRequest {}


### PR DESCRIPTION
for https://github.com/erigontech/erigon/issues/12502

reason: to reduce amount of `fsync`s on chain-tip 