### PR TITLE
grpc: domain methods rename 

### DIFF
--- a/remote/ethbackend.proto
+++ b/remote/ethbackend.proto
@@ -18,8 +18,8 @@ service ETHBACKEND {
   // Version returns the service version number
   rpc Version(google.protobuf.Empty) returns (types.VersionReply);
 
-  // LastNewBlockSeen
-  rpc LastNewBlockSeen(google.protobuf.Empty) returns (LastNewBlockSeenReply);
+  // Status
+  rpc Status(google.protobuf.Empty) returns (StatusReply);
 
   // ProtocolVersion returns the Ethereum protocol version number (e.g. 66 for ETH66).
   rpc ProtocolVersion(ProtocolVersionRequest) returns (ProtocolVersionReply);
@@ -85,7 +85,10 @@ message NetVersionRequest {}
 
 message NetVersionReply {uint64 id = 1;}
 
-message LastNewBlockSeenReply {uint64 block_number = 1;}
+message StatusReply {
+  uint64 last_new_block_seen = 1;
+  uint64 frozen_blocks = 2;
+}
 
 message NetPeerCountRequest {}
 

--- a/remote/ethbackend.proto
+++ b/remote/ethbackend.proto
@@ -90,6 +90,13 @@ message SyncingReply {
   uint64 frozen_blocks = 2;
   uint64 current_block = 3;
   bool syncing = 4;
+
+  message StageProgress {
+    string stage_name = 1;
+    uint64 block_number = 2;
+  }
+  repeated StageProgress stages = 5;
+  
 }
 
 message NetPeerCountRequest {}

--- a/remote/ethbackend.proto
+++ b/remote/ethbackend.proto
@@ -18,6 +18,9 @@ service ETHBACKEND {
   // Version returns the service version number
   rpc Version(google.protobuf.Empty) returns (types.VersionReply);
 
+  // LastNewBlockSeen
+  rpc LastNewBlockSeen(google.protobuf.Empty) returns (LastNewBlockSeenReply);
+
   // ProtocolVersion returns the Ethereum protocol version number (e.g. 66 for ETH66).
   rpc ProtocolVersion(ProtocolVersionRequest) returns (ProtocolVersionReply);
 
@@ -76,23 +79,25 @@ enum Event {
 
 message EtherbaseRequest {}
 
-message EtherbaseReply { types.H160 address = 1; }
+message EtherbaseReply {types.H160 address = 1;}
 
 message NetVersionRequest {}
 
-message NetVersionReply { uint64 id = 1; }
+message NetVersionReply {uint64 id = 1;}
+
+message LastNewBlockSeenReply {uint64 block_number = 1;}
 
 message NetPeerCountRequest {}
 
-message NetPeerCountReply { uint64 count = 1; }
+message NetPeerCountReply {uint64 count = 1;}
 
 message ProtocolVersionRequest {}
 
-message ProtocolVersionReply { uint64 id = 1; }
+message ProtocolVersionReply {uint64 id = 1;}
 
 message ClientVersionRequest {}
 
-message ClientVersionReply { string node_name = 1; }
+message ClientVersionReply {string node_name = 1;}
 
 message CanonicalHashRequest {
   uint64 block_number = 1;

--- a/remote/ethbackend.proto
+++ b/remote/ethbackend.proto
@@ -18,8 +18,8 @@ service ETHBACKEND {
   // Version returns the service version number
   rpc Version(google.protobuf.Empty) returns (types.VersionReply);
 
-  // Status
-  rpc Status(google.protobuf.Empty) returns (StatusReply);
+  // Syncing returns a data object detailing the status of the sync process
+  rpc Syncing(google.protobuf.Empty) returns (SyncingReply);
 
   // ProtocolVersion returns the Ethereum protocol version number (e.g. 66 for ETH66).
   rpc ProtocolVersion(ProtocolVersionRequest) returns (ProtocolVersionReply);
@@ -85,9 +85,11 @@ message NetVersionRequest {}
 
 message NetVersionReply {uint64 id = 1;}
 
-message StatusReply {
+message SyncingReply {
   uint64 last_new_block_seen = 1;
   uint64 frozen_blocks = 2;
+  uint64 current_block = 3;
+  bool syncing = 4;
 }
 
 message NetPeerCountRequest {}

--- a/remote/kv.proto
+++ b/remote/kv.proto
@@ -56,12 +56,12 @@ service KV {
 
 
   //Temporal methods
-  rpc DomainGet(DomainGetReq) returns (DomainGetReply); // can return latest value or as of given timestamp
+  rpc GetLatest(GetLatestReq) returns (GetLatestReply); // can return latest value or as of given timestamp
   rpc HistorySeek(HistorySeekReq) returns (HistorySeekReply);
 
   rpc IndexRange(IndexRangeReq) returns (IndexRangeReply);
   rpc HistoryRange(HistoryRangeReq) returns (Pairs);
-  rpc DomainRange(DomainRangeReq) returns (Pairs);
+  rpc RangeAsOf(RangeAsOfReq) returns (Pairs);
 
 }
 
@@ -182,7 +182,7 @@ message RangeReq  {
 
 
 //Temporal methods
-message DomainGetReq {
+message GetLatestReq {
   uint64 tx_id = 1; // returned by .Tx()
 
   // query params
@@ -193,7 +193,7 @@ message DomainGetReq {
   bool latest = 6; // if true, then `ts` ignored and return latest state (without history lookup)
 }
 
-message DomainGetReply{
+message GetLatestReply{
   bytes v = 1;
   bool ok = 2;
 }
@@ -246,7 +246,7 @@ message HistoryRangeReq {
   string page_token = 9;
 }
 
-message DomainRangeReq {
+message RangeAsOfReq {
   uint64 tx_id = 1; // returned by .Tx()
 
   // query params


### PR DESCRIPTION
Rename: 
- `DomainRange` to `RangeAsOf`
- `DomainGetAsOf` to `GetAsOf`
-  `DomainGet` to `GetLatest`
all this methods do accept typed `kv.Domain` as a parameter

merge after https://github.com/erigontech/erigon/pull/12621