### PR TITLE
remote: add block time to state change proto

### DIFF
--- a/remote/kv.proto
+++ b/remote/kv.proto
@@ -147,6 +147,7 @@ message StateChange {
   types.H256 block_hash = 3;
   repeated AccountChange changes = 4;
   repeated bytes txs = 5;     // enable by withTransactions=true
+  uint64 block_time = 6;
 }
 
 message StateChangeRequest {


### PR DESCRIPTION
used in https://github.com/erigontech/erigon/pull/13860

add `BlockTime` info to `StateChange` message
this is needed in the Shutter pool to be able to calculate the slot number associated with the given block notification