### PR TITLE
kv_proto: HistoryStartFromReq: fix field_tag for tx_id

### DIFF
--- a/remote/kv.proto
+++ b/remote/kv.proto
@@ -314,8 +314,8 @@ message HasPrefixReply {
 }
 
 message HistoryStartFromReq {
-  uint64 tx_id = 1; // returned by .Tx()
   uint32 domain = 1;
+  uint64 tx_id = 2; // returned by .Tx()
 }
 
 message HistoryStartFromReply {


### PR DESCRIPTION
This PR fix the field_tag for tx_id (in previous version I have used same tag for two fields)