### PR TITLE
eth_backend/sentry: add RemovePeer method

### DIFF
--- a/p2psentry/sentry.proto
+++ b/p2psentry/sentry.proto
@@ -97,6 +97,10 @@ message AddPeerRequest {
   string url = 1;
 }
 
+message RemovePeerRequest {
+  string url = 1;
+}
+
 message InboundMessage {
   MessageId id = 1;
   bytes data = 2;
@@ -171,6 +175,10 @@ message AddPeerReply {
   bool success = 1;
 }
 
+message RemovePeerReply {
+  bool success = 1;
+}
+
 service Sentry {
   // SetStatus - force new ETH client state of sentry - network_id, max_block, etc...
   rpc SetStatus(StatusData) returns (SetStatusReply);
@@ -199,6 +207,7 @@ service Sentry {
   rpc PeerEvents(PeerEventsRequest) returns (stream PeerEvent);
 
   rpc AddPeer(AddPeerRequest) returns (AddPeerReply);
+  rpc RemovePeer(RemovePeerRequest) returns (RemovePeerReply);
 
   // NodeInfo returns a collection of metadata known about the host.
   rpc NodeInfo(google.protobuf.Empty) returns(types.NodeInfoReply);

--- a/remote/ethbackend.proto
+++ b/remote/ethbackend.proto
@@ -58,6 +58,8 @@ service ETHBACKEND {
 
   rpc AddPeer(AddPeerRequest) returns (AddPeerReply);
 
+  rpc RemovePeer(RemovePeerRequest) returns (RemovePeerReply);
+
   // PendingBlock returns latest built block.
   rpc PendingBlock(google.protobuf.Empty) returns (PendingBlockReply);
 
@@ -194,6 +196,10 @@ message AddPeerRequest {
   string url = 1;
 }
 
+message RemovePeerRequest {
+  string url = 1;
+}
+
 message NodesInfoReply {
   repeated types.NodeInfoReply nodes_info = 1;
 }
@@ -203,6 +209,10 @@ message PeersReply {
 }
 
 message AddPeerReply {
+  bool success = 1;
+}
+
+message RemovePeerReply {
   bool success = 1;
 }
 


### PR DESCRIPTION
This PR introduce the possibility to call RemovePeer via grpc
To close issue on  availabilty of RemovePeer() method on RPC API