### PR TITLE
BlobsBundleV1 -> BlobsBundle

### DIFF
--- a/execution/execution.proto
+++ b/execution/execution.proto
@@ -141,7 +141,7 @@ message GetAssembledBlockRequest {
 message AssembledBlockData {
     types.ExecutionPayload execution_payload = 1;
     types.H256 block_value = 2;
-    types.BlobsBundleV1 blobs_bundle = 3;
+    types.BlobsBundle blobs_bundle = 3;
     types.RequestsBundle requests = 4;
 }
 

--- a/types/types.proto
+++ b/types/types.proto
@@ -86,7 +86,7 @@ message Withdrawal {
   uint64 amount = 4;
 }
 
-message BlobsBundleV1 {
+message BlobsBundle {
   // TODO(eip-4844): define a protobuf message for type KZGCommitment
   repeated bytes commitments = 1;
   // TODO(eip-4844): define a protobuf message for type Blob


### PR DESCRIPTION
Our `BlobsBundle` covers both [BlobsBundleV1](https://github.com/ethereum/execution-apis/blob/main/src/engine/cancun.md#blobsbundlev1) and [BlobsBundleV2](https://github.com/ethereum/execution-apis/blob/main/src/engine/osaka.md#blobsbundlev2).